### PR TITLE
Add shared travel planner FastAPI starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
-# hello-world
-This is a test of the emergency repository system. This is only a test.
+# Shared Travel Planner
 
+A starter FastAPI service for collaboratively building itineraries. Users can register/login, create trips with flights and hotels, and share trips with other accounts.
 
-Help, help I'm being repressed.
+## Features
+- Email/password registration with hashed credentials and JWT login tokens
+- Create trips with optional start/end dates
+- Add flights (airline, airports, times) and hotels (city, check-in/out) to a trip
+- Share trips with other registered users for read/write access
+- SQLite persistence by default
 
+## Getting started
+1. Install dependencies (recommend a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the API server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Open the interactive docs at `http://127.0.0.1:8000/docs` to try the endpoints.
+
+## API highlights
+- `POST /auth/register` – create an account
+- `POST /auth/login` – obtain an access token (send `username` + `password` form fields)
+- `POST /trips` – create a trip with optional flights/hotels payloads
+- `GET /trips` and `GET /trips/{trip_id}` – view trips you own or that are shared with you
+- `POST /trips/{trip_id}/share` – share a trip with another registered email
+- `POST /trips/{trip_id}/flights` and `POST /trips/{trip_id}/hotels` – append items to an existing trip
+
+Use the `Authorization: Bearer <token>` header for all `/trips` endpoints.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,54 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlmodel import Session, select
+
+from .db import get_session
+from .models import User
+
+SECRET_KEY = "change-me-in-production"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def get_current_user(session: Session = Depends(get_session), token: str = Depends(oauth2_scheme)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: Optional[str] = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+
+    user = session.exec(select(User).where(User.id == int(user_id))).first()
+    if user is None:
+        raise credentials_exception
+    return user

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,9 @@
+from sqlmodel import Session, create_engine
+
+DATABASE_URL = "sqlite:///./app.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,215 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import Session, SQLModel, select
+
+from .auth import create_access_token, get_current_user, get_password_hash, verify_password
+from .db import engine, get_session
+from .models import Flight, Hotel, Trip, TripShare, User
+from .schemas import FlightCreate, HotelCreate, ShareRequest, Token, TripCreate, TripRead, UserCreate, UserRead
+
+app = FastAPI(title="Shared Travel Planner")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+@app.post("/auth/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+def register(user_create: UserCreate, session: Session = Depends(get_session)) -> UserRead:
+    existing_user = session.exec(select(User).where(User.email == user_create.email)).first()
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+
+    hashed_password = get_password_hash(user_create.password)
+    user = User(email=user_create.email, hashed_password=hashed_password)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return UserRead(id=user.id, email=user.email)
+
+
+@app.post("/auth/login", response_model=Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), session: Session = Depends(get_session)) -> Token:
+    user = session.exec(select(User).where(User.email == form_data.username)).first()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect email or password")
+
+    access_token = create_access_token({"sub": str(user.id)})
+    return Token(access_token=access_token)
+
+
+@app.post("/trips", response_model=TripRead, status_code=status.HTTP_201_CREATED)
+def create_trip(trip_create: TripCreate, session: Session = Depends(get_session), current_user: User = Depends(get_current_user)) -> TripRead:
+    trip = Trip(
+        name=trip_create.name,
+        owner_id=current_user.id,
+        start_date=trip_create.start_date,
+        end_date=trip_create.end_date,
+    )
+    session.add(trip)
+    session.commit()
+    session.refresh(trip)
+
+    flights = [
+        Flight(
+            trip_id=trip.id,
+            airline=flight.airline,
+            departure_airport=flight.departure_airport,
+            arrival_airport=flight.arrival_airport,
+            departure_time=flight.departure_time,
+            arrival_time=flight.arrival_time,
+        )
+        for flight in trip_create.flights
+    ]
+    hotels = [
+        Hotel(
+            trip_id=trip.id,
+            name=hotel.name,
+            city=hotel.city,
+            check_in=hotel.check_in,
+            check_out=hotel.check_out,
+        )
+        for hotel in trip_create.hotels
+    ]
+    session.add_all(flights + hotels)
+    session.commit()
+
+    return _trip_to_read(trip, flights, hotels, [])
+
+
+@app.get("/trips", response_model=List[TripRead])
+def list_trips(session: Session = Depends(get_session), current_user: User = Depends(get_current_user)) -> List[TripRead]:
+    owned_trips = session.exec(select(Trip).where(Trip.owner_id == current_user.id)).all()
+    shared_trip_ids = session.exec(select(TripShare.trip_id).where(TripShare.user_id == current_user.id)).all()
+    shared_trips = []
+    if shared_trip_ids:
+        shared_trips = session.exec(select(Trip).where(Trip.id.in_(shared_trip_ids))).all()
+
+    trips = owned_trips + [trip for trip in shared_trips if trip not in owned_trips]
+
+    return [_trip_to_read(trip, _fetch_flights(session, trip.id), _fetch_hotels(session, trip.id), _fetch_share_ids(session, trip.id)) for trip in trips]
+
+
+@app.get("/trips/{trip_id}", response_model=TripRead)
+def get_trip(trip_id: int, session: Session = Depends(get_session), current_user: User = Depends(get_current_user)) -> TripRead:
+    trip = session.get(Trip, trip_id)
+    if not trip:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+
+    if trip.owner_id != current_user.id and not _user_has_access(session, current_user.id, trip_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to view this trip")
+
+    return _trip_to_read(trip, _fetch_flights(session, trip_id), _fetch_hotels(session, trip_id), _fetch_share_ids(session, trip_id))
+
+
+@app.post("/trips/{trip_id}/share", status_code=status.HTTP_204_NO_CONTENT)
+def share_trip(trip_id: int, share_request: ShareRequest, session: Session = Depends(get_session), current_user: User = Depends(get_current_user)) -> None:
+    trip = session.get(Trip, trip_id)
+    if not trip:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    if trip.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can share the trip")
+
+    target_user = session.exec(select(User).where(User.email == share_request.email)).first()
+    if not target_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User to share with was not found")
+    if target_user.id == current_user.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot share a trip with yourself")
+
+    existing_share = session.exec(
+        select(TripShare).where(TripShare.trip_id == trip_id, TripShare.user_id == target_user.id)
+    ).first()
+    if existing_share:
+        return
+
+    share = TripShare(trip_id=trip_id, user_id=target_user.id, created_at=datetime.utcnow())
+    session.add(share)
+    session.commit()
+
+
+@app.post("/trips/{trip_id}/flights", response_model=TripRead)
+def add_flight(
+    trip_id: int,
+    flight: FlightCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> TripRead:
+    _ensure_trip_access(session, current_user.id, trip_id)
+    flight_row = Flight(trip_id=trip_id, **flight.dict())
+    session.add(flight_row)
+    session.commit()
+    return _trip_to_read(
+        session.get(Trip, trip_id),
+        _fetch_flights(session, trip_id),
+        _fetch_hotels(session, trip_id),
+        _fetch_share_ids(session, trip_id),
+    )
+
+
+@app.post("/trips/{trip_id}/hotels", response_model=TripRead)
+def add_hotel(
+    trip_id: int,
+    hotel: HotelCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> TripRead:
+    _ensure_trip_access(session, current_user.id, trip_id)
+    hotel_row = Hotel(trip_id=trip_id, **hotel.dict())
+    session.add(hotel_row)
+    session.commit()
+    return _trip_to_read(
+        session.get(Trip, trip_id),
+        _fetch_flights(session, trip_id),
+        _fetch_hotels(session, trip_id),
+        _fetch_share_ids(session, trip_id),
+    )
+
+
+def _fetch_flights(session: Session, trip_id: int) -> List[Flight]:
+    return session.exec(select(Flight).where(Flight.trip_id == trip_id)).all()
+
+
+def _fetch_hotels(session: Session, trip_id: int) -> List[Hotel]:
+    return session.exec(select(Hotel).where(Hotel.trip_id == trip_id)).all()
+
+
+def _fetch_share_ids(session: Session, trip_id: int) -> List[int]:
+    return [share.user_id for share in session.exec(select(TripShare).where(TripShare.trip_id == trip_id)).all()]
+
+
+def _user_has_access(session: Session, user_id: int, trip_id: int) -> bool:
+    share = session.exec(select(TripShare).where(TripShare.trip_id == trip_id, TripShare.user_id == user_id)).first()
+    return share is not None
+
+
+def _ensure_trip_access(session: Session, user_id: int, trip_id: int) -> None:
+    trip = session.get(Trip, trip_id)
+    if not trip:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    if trip.owner_id != user_id and not _user_has_access(session, user_id, trip_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized for this trip")
+
+
+def _trip_to_read(trip: Trip, flights: List[Flight], hotels: List[Hotel], shared_ids: List[int]) -> TripRead:
+    return TripRead(
+        id=trip.id,
+        name=trip.name,
+        owner_id=trip.owner_id,
+        start_date=trip.start_date,
+        end_date=trip.end_date,
+        flights=flights,
+        hotels=hotels,
+        shared_with_user_ids=shared_ids,
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,60 @@
+from datetime import date, datetime
+from typing import List, Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class TripShare(SQLModel, table=True):
+    trip_id: Optional[int] = Field(default=None, foreign_key="trip.id", primary_key=True)
+    user_id: Optional[int] = Field(default=None, foreign_key="user.id", primary_key=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    trip: "Trip" = Relationship(back_populates="shared_with")
+    user: "User" = Relationship(back_populates="shared_trips")
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, unique=True)
+    hashed_password: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    trips: List["Trip"] = Relationship(back_populates="owner")
+    shared_trips: List[TripShare] = Relationship(back_populates="user")
+
+
+class Trip(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    owner_id: int = Field(foreign_key="user.id")
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    owner: User = Relationship(back_populates="trips")
+    flights: List["Flight"] = Relationship(back_populates="trip")
+    hotels: List["Hotel"] = Relationship(back_populates="trip")
+    shared_with: List[TripShare] = Relationship(back_populates="trip")
+
+
+class Flight(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    trip_id: int = Field(foreign_key="trip.id")
+    airline: str
+    departure_airport: str
+    arrival_airport: str
+    departure_time: datetime
+    arrival_time: datetime
+
+    trip: Trip = Relationship(back_populates="flights")
+
+
+class Hotel(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    trip_id: int = Field(foreign_key="trip.id")
+    name: str
+    city: str
+    check_in: date
+    check_out: date
+
+    trip: Trip = Relationship(back_populates="hotels")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,71 @@
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, EmailStr, validator
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+    @validator("password")
+    def password_length(cls, value: str) -> str:
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        return value
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserRead(BaseModel):
+    id: int
+    email: EmailStr
+
+
+class FlightCreate(BaseModel):
+    airline: str
+    departure_airport: str
+    arrival_airport: str
+    departure_time: datetime
+    arrival_time: datetime
+
+
+class HotelCreate(BaseModel):
+    name: str
+    city: str
+    check_in: date
+    check_out: date
+
+
+class TripBase(BaseModel):
+    name: str
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+
+
+class TripCreate(TripBase):
+    flights: List[FlightCreate] = []
+    hotels: List[HotelCreate] = []
+
+
+class FlightRead(FlightCreate):
+    id: int
+
+
+class HotelRead(HotelCreate):
+    id: int
+
+
+class TripRead(TripBase):
+    id: int
+    owner_id: int
+    flights: List[FlightRead]
+    hotels: List[HotelRead]
+    shared_with_user_ids: List[int]
+
+
+class ShareRequest(BaseModel):
+    email: EmailStr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+sqlmodel==0.0.14
+python-jose==3.3.0
+passlib[bcrypt]==1.7.4
+pydantic==1.10.14


### PR DESCRIPTION
## Summary
- scaffold a FastAPI-based shared travel planner with authentication, trip creation, and sharing APIs
- define SQLModel entities for users, trips, flights, hotels, and trip sharing relationships
- document setup steps and usage in the README and add required dependencies

## Testing
- python -m pip install -r requirements.txt *(fails: proxy blocked PyPI access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ca33faab0832d9d1c4fa94e40d35d)